### PR TITLE
[Task] detailpage widget & components responsive, fix twitter id

### DIFF
--- a/src/pages/Detailpage/Detailpage.tsx
+++ b/src/pages/Detailpage/Detailpage.tsx
@@ -5,11 +5,11 @@ import { Flex, Box, VStack } from '@chakra-ui/react';
 import { useParams } from 'react-router-dom';
 import { fetchSinglePost } from '@/service/ghostAPI';
 import { renderHTMLContent } from '@/util/renderHTMLContent';
+import { months } from '@/types/constant';
 import { DetailpageProps } from '../../types/interface';
 import useFetch from '../../hooks/useFetch';
 import Loading from '../Loading';
 import PageNotFound from '../PageNotFound';
-import { months } from '@/types/constant';
 
 const Detailpage: React.FC<DetailpageProps> = () => {
     const { postId } = useParams();

--- a/src/pages/Detailpage/Render.tsx
+++ b/src/pages/Detailpage/Render.tsx
@@ -61,30 +61,19 @@ const Render = {
             </video>
         </Flex>
     ),
-    youtube: (id: number, title: string, src: string, isYoutube: boolean) => (
-        // kalo mau responsive ini aspect rationya diedit untuk spotify
+    iframe: (id: number, attr: any, aspectRatio: boolean) => (
         <div
             key={id}
             className={`w-full max-w-screen-sm flex justify-center ${
-                isYoutube ? 'aspect-video' : 'aspect-video'
+                aspectRatio ? 'aspect-video' : ''
             }`}
         >
-            <iframe
-                src={src}
-                frameBorder="0"
-                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-                allowFullScreen
-                title={title}
-                width="80%"
-            />
+            <iframe title={attr.title} {...attr} />
         </div>
     ),
-    twitter: () => (
-        <div className="w-full">
-            <Tweet
-                tweetId="1552277594707742720"
-                options={{ align: 'center' }}
-            />
+    twitter: (id: number, tweetId: string) => (
+        <div key={id} className="w-full">
+            <Tweet tweetId={tweetId} options={{ align: 'center' }} />
         </div>
     ),
     divider: () => (

--- a/src/pages/Detailpage/Render.tsx
+++ b/src/pages/Detailpage/Render.tsx
@@ -49,13 +49,11 @@ const Render = {
             <Text as="u">{text}</Text>
         </Link>
     ),
-    image: (id: number, src: string) => {
-        return (
-            <Center key={id}>
-                <img src={formatUrl(src)} alt="content" width="80%" />
-            </Center>
-        );
-    },
+    image: (id: number, src: string) => (
+        <Center key={id}>
+            <img src={formatUrl(src)} alt="content" width="80%" />
+        </Center>
+    ),
     video: (id: number, pathOfThumbnail: string, src: string) => (
         <Flex key={id} alignItems="center" justifyContent="center">
             <video controls poster={pathOfThumbnail} width="80%">
@@ -162,10 +160,10 @@ const Render = {
         return (
             <VStack
                 key={id}
-                className="block p-6 rounded-lg shadow-lg bg-white max-w-sm"
+                className="block p-5 md:p-7 w-40 sm:w-60 md:w-72 lg:w-80 rounded-lg shadow-lg bg-white"
             >
                 <Center>{titleAudio}</Center>
-                <audio controls>
+                <audio controls className="w-full">
                     <source src={formatUrl(src)} type="audio/mpeg" />
                 </audio>
             </VStack>
@@ -195,8 +193,8 @@ const Render = {
                 width="100%"
                 bg="rgba(255,235,176,0.65)"
             >
-                <Text fontSize="5xl">{textHeader}</Text>
-                <Text fontSize="3xl">{textSubHeader}</Text>
+                <Text fontSize={['2xl', '3xl', '4xl']}>{textHeader}</Text>
+                <Text fontSize={['lg', 'xl', '2xl']}>{textSubHeader}</Text>
             </VStack>
         );
     },
@@ -207,15 +205,19 @@ const Render = {
         const button = node.childNodes[0].childNodes[3]?.attrs.href;
         const buttonText = node.childNodes[0].childNodes[3]?.text;
         return (
-            <div className="max-w-sm rounded overflow-hidden shadow-lg">
+            <div className="w-40 sm:w-44 md:w-60 lg:w-80 rounded overflow-hidden shadow-lg bg-LightBrown">
                 <img
                     className="w-full"
                     src={formatUrl(srcImage)}
                     alt="product"
                 />
-                <div className="px-6 py-4">
-                    <div className="font-bold text-xl mb-2">{title}</div>
-                    <p className="text-gray-700 text-base">{description}</p>
+                <div className="px-3 py-2 md:px-6 md:py-4">
+                    <div className="font-bold text-md sm:text-lg md:text-xl mb-2">
+                        {title}
+                    </div>
+                    <p className="text-gray-700 text-sm sm:text-base md:text-lg">
+                        {description}
+                    </p>
                 </div>
                 {button && (
                     <Center className="px-6 pt-2 pb-2">

--- a/src/util/renderHTMLContent.ts
+++ b/src/util/renderHTMLContent.ts
@@ -58,25 +58,38 @@ export const renderHTMLContent = (post: any) => {
                     node.childNodes[0].childNodes[0].attrs.src
                 );
             } else if (includes(node.attrs.class, 'kg-embed-card')) {
+                let attr;
+                let aspectRatio = false;
+                if (node.childNodes[0].attrs.src) {
+                    attr = {
+                        allow: node.childNodes[0].attrs.allow,
+                        allowFullScreen:
+                            node.childNodes[0].attrs.allowfullscreen,
+                        frameBorder: node.childNodes[0].attrs.frameborder,
+                        src: node.childNodes[0].attrs.src,
+                        title: node.childNodes[0].attrs.tile,
+                        height: node.childNodes[0].attrs.height,
+                        width: node.childNodes[0].attrs.width,
+                    };
+                    if (
+                        includes(node.childNodes[0].rawAttrs, 'www.youtube.com')
+                    ) {
+                        attr.width = '100%';
+                        delete attr?.height;
+                        aspectRatio = true;
+                    }
+                }
                 if (node.childNodes[0].attrs.class === 'twitter-tweet') {
-                    component = Render.twitter();
-                } else if (
-                    // render for embed, youtube & spotify
-                    includes(node.childNodes[0].rawAttrs, 'www.youtube.com')
-                ) {
-                    component = Render.youtube(
-                        id,
-                        node.childNodes[0].attrs.title,
-                        node.childNodes[0].attrs.src,
-                        true
-                    );
+                    // twitter
+                    const src = node.childNodes[0].childNodes[2].rawAttrs;
+                    const idExp = /status\/(\d+)/g;
+                    const regexExp = new RegExp(idExp);
+                    const match = regexExp.exec(src);
+                    const tweetId = match![1];
+                    component = Render.twitter(id, tweetId);
                 } else {
-                    component = Render.youtube(
-                        id,
-                        node.childNodes[0].attrs.title,
-                        node.childNodes[0].attrs.src,
-                        false
-                    );
+                    // youtube & spotify
+                    component = Render.iframe(id, attr, aspectRatio);
                 }
             } else if (includes(node.attrs.class, 'kg-gallery-card')) {
                 component = Render.gallery(id, node);


### PR DESCRIPTION
## Story/Task

_detailpage widget & product/heading/music responsive, fix twitter id_

## Summary

-   _use regex to get twitter id_
-   _add abstraction to iframe render for youtube & spotify_
-   _fix responsive for product, header, music_

## Test Plan
_none_

## Screenshot
![image](https://user-images.githubusercontent.com/71055612/181430945-a28acf28-fe3d-4c12-a835-eac476218b41.png)
![image](https://user-images.githubusercontent.com/71055612/181430979-c894cb86-7e40-4049-ab9d-562597d4fe07.png)
![image](https://user-images.githubusercontent.com/71055612/181431012-bc92407b-dda8-49d9-87d6-5b4f4642f727.png)
![image](https://user-images.githubusercontent.com/71055612/181431125-fe5d445b-f7e4-49ca-8d74-f683dcfee3d4.png)
![image](https://user-images.githubusercontent.com/71055612/181431167-07d0ec0a-161a-4a06-aa39-dcca49cd1977.png)
