### PR TITLE
fix: responsive card image

### DIFF
--- a/src/components/BlogPost.tsx
+++ b/src/components/BlogPost.tsx
@@ -42,7 +42,7 @@ const BlogPost: React.FC<BlogPostCard> = (props) => {
             <img
                 alt={title}
                 src={formattedUrl}
-                className="max-h-40 w-full object-cover rounded-t-lg"
+                className="min-h-[160px] max-h-40 w-full object-cover rounded-t-lg"
             />
             <div
                 className={`bg-white w-full h-full ${
@@ -84,8 +84,8 @@ const BlogPost: React.FC<BlogPostCard> = (props) => {
                     </Link>
                     {/* tags  */}
                     <div>
-                        {tags ? (
-                            <div className="flex items-center mt-2 flex-wrap gap-2">
+                        {tags && tags.length > 0 ? (
+                            <div className="flex items-center mt-6 flex-wrap gap-2 gap-y-5">
                                 {tags.map((tag) => (
                                     // TODO: change # to tags link
                                     <a


### PR DESCRIPTION
## Story/Task

_fix: responsive card image_

## Summary

-   _fix: responsive card image_

## Screenshot
before after
![image](https://user-images.githubusercontent.com/71055612/184131262-42472cc6-7265-431f-bcbf-025f567c3ed8.png)
