### PR TITLE
fix: set mobile width to 90%

### DIFF
--- a/src/layout/BaseLayout.tsx
+++ b/src/layout/BaseLayout.tsx
@@ -101,7 +101,10 @@ const BaseLayout: React.FC<BaseProps> = (props) => {
                     className="mx-auto"
                     borderBottom={isOpen ? '1px solid' : 'none'}
                 >
-                    <Link className="h-full min-w-max flex items-center" to="/">
+                    <Link
+                        className="h-full min-w-max mr-3 flex items-center"
+                        to="/"
+                    >
                         <img
                             className="h-[75%] md:h-[90%]"
                             src={defaultLogo}

--- a/src/pages/Detailpage/Detailpage.tsx
+++ b/src/pages/Detailpage/Detailpage.tsx
@@ -125,7 +125,7 @@ const Detailpage: React.FC<DetailpageProps> = ({
             <Flex
                 className="my-12 md:my-20 max-w-screen-lg"
                 flexDirection="column"
-                width="70%"
+                width={{ base: '90%', sm: '70%' }}
             >
                 <Box
                     fontFamily="Magilio"


### PR DESCRIPTION
## Story/Task

_set mobile width to 90% for twitter responsive_

## Summary

-  _set mobile width to 90% for twitter responsive (previosly 70%)_

## Screenshot
before:
![image](https://user-images.githubusercontent.com/71055612/184938602-055d0a6f-ff84-42ba-82e4-b8738526081d.png)

after:
![image](https://user-images.githubusercontent.com/71055612/184938685-04091142-d18b-475f-80c4-ad02272442b2.png)

![image](https://user-images.githubusercontent.com/71055612/184943498-5e88a252-c9ef-43c7-a7ed-11c9f066784b.png)

